### PR TITLE
Add DriverInfo support for Redis client identification

### DIFF
--- a/fastapi_redis_session/session.py
+++ b/fastapi_redis_session/session.py
@@ -6,14 +6,17 @@ from redis import Redis
 from .config import config
 
 try:
-    from importlib.metadata import version as get_version
+    from importlib.metadata import PackageNotFoundError, version as get_version
 except ImportError:  # Python < 3.8
     try:
-        from importlib_metadata import version as get_version  # type: ignore
+        from importlib_metadata import PackageNotFoundError, version as get_version  # type: ignore
     except ImportError:
 
+        class PackageNotFoundError(Exception):  # type: ignore
+            pass
+
         def get_version(_name: str) -> str:
-            return "unknown"
+            raise PackageNotFoundError(_name)
 
 
 class SessionStorage:
@@ -47,7 +50,7 @@ class SessionStorage:
         # Get fastapi-redis-session version
         try:
             session_version = get_version("fastapi-redis-session")
-        except Exception:
+        except PackageNotFoundError:
             session_version = "unknown"
 
         # Get connection pool from the redis client

--- a/fastapi_redis_session/session.py
+++ b/fastapi_redis_session/session.py
@@ -7,8 +7,13 @@ from .config import config
 
 try:
     from importlib.metadata import version as get_version
-except ImportError:
-    from importlib_metadata import version as get_version
+except ImportError:  # Python < 3.8
+    try:
+        from importlib_metadata import version as get_version  # type: ignore
+    except ImportError:
+
+        def get_version(_name: str) -> str:
+            return "unknown"
 
 
 class SessionStorage:

--- a/fastapi_redis_session/session.py
+++ b/fastapi_redis_session/session.py
@@ -33,7 +33,7 @@ class SessionStorage:
         return sessionId
 
     @staticmethod
-    def _add_driver_info(redis) -> None:
+    def _add_driver_info(redis_client) -> None:
         """Add driver identification to Redis connection.
 
         Uses DriverInfo class if available, or falls back to
@@ -46,7 +46,7 @@ class SessionStorage:
             session_version = "unknown"
 
         # Get connection pool from the redis client
-        connection_pool: Any = getattr(redis, "connection_pool", None)
+        connection_pool: Any = getattr(redis_client, "connection_pool", None)
         if connection_pool is None:
             return
 
@@ -62,9 +62,9 @@ class SessionStorage:
             connection_pool.connection_kwargs["lib_name"] = f"redis-py(fastapi-redis-session_v{session_version})"
             # lib_version should be the redis client version
             try:
-                import redis
+                import redis as redis_module
 
-                redis_version = redis.__version__
+                redis_version = redis_module.__version__
             except (ImportError, AttributeError):
                 redis_version = "unknown"
             connection_pool.connection_kwargs["lib_version"] = redis_version

--- a/fastapi_redis_session/session.py
+++ b/fastapi_redis_session/session.py
@@ -5,10 +5,16 @@ from redis import Redis
 
 from .config import config
 
+try:
+    from importlib.metadata import version as get_version
+except ImportError:
+    from importlib_metadata import version as get_version
+
 
 class SessionStorage:
     def __init__(self):
         self.client = Redis.from_url(config.redisURL)
+        self._add_driver_info(self.client)
 
     def __getitem__(self, key: str):
         raw = self.client.get(key)
@@ -25,3 +31,40 @@ class SessionStorage:
         while self.client.get(sessionId):
             sessionId = config.genSessionId()
         return sessionId
+
+    @staticmethod
+    def _add_driver_info(redis) -> None:
+        """Add driver identification to Redis connection.
+
+        Uses DriverInfo class if available, or falls back to
+        lib_name/lib_version for older versions.
+        """
+        # Get fastapi-redis-session version
+        try:
+            session_version = get_version("fastapi-redis-session")
+        except Exception:
+            session_version = "unknown"
+
+        # Get connection pool from the redis client
+        connection_pool: Any = getattr(redis, "connection_pool", None)
+        if connection_pool is None:
+            return
+
+        # Try to use DriverInfo class
+        try:
+            from redis import DriverInfo
+
+            driver_info = DriverInfo().add_upstream_driver("fastapi-redis-session", session_version)
+            connection_pool.connection_kwargs["driver_info"] = driver_info
+        except (ImportError, AttributeError):
+            # Fallback: use lib_name/lib_version
+            # Format: lib_name='redis-py(fastapi-redis-session_v{version})'
+            connection_pool.connection_kwargs["lib_name"] = f"redis-py(fastapi-redis-session_v{session_version})"
+            # lib_version should be the redis client version
+            try:
+                import redis
+
+                redis_version = redis.__version__
+            except (ImportError, AttributeError):
+                redis_version = "unknown"
+            connection_pool.connection_kwargs["lib_version"] = redis_version

--- a/tests/test_driver_info.py
+++ b/tests/test_driver_info.py
@@ -1,0 +1,167 @@
+"""Tests for Redis DriverInfo support in SessionStorage."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from fastapi_redis_session.session import SessionStorage
+
+
+class TestDriverInfo:
+    """Test suite for Redis driver info functionality."""
+
+    def test_add_driver_info_with_driver_info_class(self):
+        """Test _add_driver_info with modern redis-py (DriverInfo class available)."""
+        mock_redis = MagicMock()
+        mock_pool = MagicMock()
+        mock_pool.connection_kwargs = {}
+        mock_redis.connection_pool = mock_pool
+
+        # Create a mock DriverInfo instance with add_upstream_driver method
+        mock_driver_info_instance = MagicMock()
+        mock_driver_info_instance.add_upstream_driver = MagicMock(return_value=mock_driver_info_instance)
+
+        # Create a mock DriverInfo class
+        mock_driver_info_class = MagicMock(return_value=mock_driver_info_instance)
+
+        # Create a mock redis module with DriverInfo
+        mock_redis_module = MagicMock()
+        mock_redis_module.DriverInfo = mock_driver_info_class
+
+        with patch("fastapi_redis_session.session.get_version", return_value="0.2.0"):
+            # Temporarily add our mock redis module
+            original_redis = sys.modules.get("redis")
+            sys.modules["redis"] = mock_redis_module
+
+            try:
+                SessionStorage._add_driver_info(mock_redis)
+
+                # Verify driver_info was set in connection_kwargs
+                assert "driver_info" in mock_pool.connection_kwargs
+
+                # Verify add_upstream_driver was called with correct arguments
+                mock_driver_info_instance.add_upstream_driver.assert_called_once_with("fastapi-redis-session", "0.2.0")
+            finally:
+                # Restore original redis module
+                if original_redis:
+                    sys.modules["redis"] = original_redis
+                else:
+                    sys.modules.pop("redis", None)
+
+    def test_add_driver_info_fallback_old_redis(self):
+        """Test _add_driver_info fallback for older redis-py versions (no DriverInfo)."""
+        mock_redis = MagicMock()
+        mock_pool = MagicMock()
+        mock_pool.connection_kwargs = {}
+        mock_redis.connection_pool = mock_pool
+
+        # Create a mock redis module WITHOUT DriverInfo but WITH __version__
+        mock_redis_module = MagicMock(spec=["__version__"])
+        mock_redis_module.__version__ = "3.5.3"
+
+        with patch("fastapi_redis_session.session.get_version", return_value="0.2.0"):
+            # Temporarily replace redis module
+            original_redis = sys.modules.get("redis")
+            sys.modules["redis"] = mock_redis_module
+
+            try:
+                SessionStorage._add_driver_info(mock_redis)
+
+                # For older redis-py versions without DriverInfo, should fall back to lib_name and lib_version
+                assert "driver_info" not in mock_pool.connection_kwargs
+                assert mock_pool.connection_kwargs["lib_name"] == "redis-py(fastapi-redis-session_v0.2.0)"
+                assert mock_pool.connection_kwargs["lib_version"] == "3.5.3"
+            finally:
+                # Restore original redis module
+                if original_redis:
+                    sys.modules["redis"] = original_redis
+                else:
+                    sys.modules.pop("redis", None)
+
+    def test_add_driver_info_no_connection_pool(self):
+        """Test _add_driver_info when redis client has no connection_pool."""
+        mock_redis = MagicMock()
+        mock_redis.connection_pool = None
+
+        # Should not raise an exception
+        SessionStorage._add_driver_info(mock_redis)
+
+    def test_add_driver_info_unknown_version(self):
+        """Test _add_driver_info when version cannot be determined."""
+        mock_redis = MagicMock()
+        mock_pool = MagicMock()
+        mock_pool.connection_kwargs = {}
+        mock_redis.connection_pool = mock_pool
+
+        # Create a mock DriverInfo instance with add_upstream_driver method
+        mock_driver_info_instance = MagicMock()
+        mock_driver_info_instance.add_upstream_driver = MagicMock(return_value=mock_driver_info_instance)
+
+        # Create a mock DriverInfo class
+        mock_driver_info_class = MagicMock(return_value=mock_driver_info_instance)
+
+        # Create a mock redis module with DriverInfo
+        mock_redis_module = MagicMock()
+        mock_redis_module.DriverInfo = mock_driver_info_class
+
+        with patch("fastapi_redis_session.session.get_version", side_effect=Exception("Version not found")):
+            # Temporarily add our mock redis module
+            original_redis = sys.modules.get("redis")
+            sys.modules["redis"] = mock_redis_module
+
+            try:
+                SessionStorage._add_driver_info(mock_redis)
+
+                # Should use "unknown" as version
+                assert "driver_info" in mock_pool.connection_kwargs
+
+                # Verify add_upstream_driver was called with "unknown" version
+                mock_driver_info_instance.add_upstream_driver.assert_called_once_with(
+                    "fastapi-redis-session", "unknown"
+                )
+            finally:
+                # Restore original redis module
+                if original_redis:
+                    sys.modules["redis"] = original_redis
+                else:
+                    sys.modules.pop("redis", None)
+
+    def test_add_driver_info_fallback_no_redis_version(self):
+        """Test _add_driver_info fallback when redis version cannot be determined."""
+        mock_redis = MagicMock()
+        mock_pool = MagicMock()
+        mock_pool.connection_kwargs = {}
+        mock_redis.connection_pool = mock_pool
+
+        # Create a mock redis module WITHOUT DriverInfo and WITHOUT __version__
+        mock_redis_module = MagicMock(spec=[])
+
+        with patch("fastapi_redis_session.session.get_version", return_value="0.2.0"):
+            # Temporarily replace redis module
+            original_redis = sys.modules.get("redis")
+            sys.modules["redis"] = mock_redis_module
+
+            try:
+                SessionStorage._add_driver_info(mock_redis)
+
+                # Should fall back to lib_name and lib_version with "unknown" for redis version
+                assert "driver_info" not in mock_pool.connection_kwargs
+                assert mock_pool.connection_kwargs["lib_name"] == "redis-py(fastapi-redis-session_v0.2.0)"
+                assert mock_pool.connection_kwargs["lib_version"] == "unknown"
+            finally:
+                # Restore original redis module
+                if original_redis:
+                    sys.modules["redis"] = original_redis
+                else:
+                    sys.modules.pop("redis", None)
+
+    def test_init_calls_add_driver_info(self):
+        """Test that SessionStorage.__init__ calls _add_driver_info."""
+        with patch("fastapi_redis_session.session.Redis.from_url") as mock_from_url:
+            mock_redis = MagicMock()
+            mock_from_url.return_value = mock_redis
+
+            with patch.object(SessionStorage, "_add_driver_info") as mock_add_driver_info:
+                SessionStorage()
+
+                # Verify _add_driver_info was called with the redis instance
+                mock_add_driver_info.assert_called_once_with(mock_redis)

--- a/tests/test_driver_info.py
+++ b/tests/test_driver_info.py
@@ -103,7 +103,12 @@ class TestDriverInfo:
         mock_redis_module = MagicMock()
         mock_redis_module.DriverInfo = mock_driver_info_class
 
-        with patch("fastapi_redis_session.session.get_version", side_effect=Exception("Version not found")):
+        from fastapi_redis_session.session import PackageNotFoundError
+
+        with patch(
+            "fastapi_redis_session.session.get_version",
+            side_effect=PackageNotFoundError("fastapi-redis-session"),
+        ):
             # Temporarily add our mock redis module
             original_redis = sys.modules.get("redis")
             sys.modules["redis"] = mock_redis_module


### PR DESCRIPTION
## Description

Adds support for redis-py's `DriverInfo` class to identify fastapi-redis-session as an upstream driver in Redis connection metadata, following the Redis client library identification guidance.

This improves observability for Redis administrators by making fastapi-redis-session connections easily identifiable when inspecting connected clients (e.g., via `CLIENT LIST` or `CLIENT INFO` commands).

## Changes

- Add `_add_driver_info()` method to `SessionStorage` class
- Use `DriverInfo` class when available
- Fallback to `lib_name`/`lib_version` for older redis-py versions
- Add comprehensive unit tests in `tests/test_driver_info.py`

## Motivation

Redis recommends that client libraries identify themselves using `CLIENT SETINFO` to help administrators understand which applications are connected. This change aligns fastapi-redis-session with this best practice by:

- Setting `lib-name` to identify fastapi-redis-session as the upstream driver (e.g., `redis-py(fastapi-redis-session_v0.2.0)`)
- Setting `lib-ver` to the redis-py client version
- Making fastapi-redis-session connections distinguishable from other redis-py users

## Compatibility

The implementation gracefully handles different redis-py versions:
- **Modern redis-py**: Uses `DriverInfo` class (preferred method)
- **Older redis-py**: Uses `lib_name`/`lib_version` fallback

## Testing

- Added 6 unit tests covering all code paths
- All existing tests pass
- Gracefully handles missing connection pools and unknown redis-py versions